### PR TITLE
Add keyboard shortcuts and redo support for counters

### DIFF
--- a/blackjack_counter/app.py
+++ b/blackjack_counter/app.py
@@ -2,7 +2,7 @@
 
 import tkinter as tk
 from tkinter import ttk
-from typing import Dict
+from typing import Dict, Optional
 
 from blackjack_counter.frames.hilo import HiLoFrame
 from blackjack_counter.frames.menu import ModeSelection, StartMenu
@@ -27,6 +27,7 @@ class CountingApp(tk.Tk):
         container.grid_columnconfigure(0, weight=1)
 
         self.frames: Dict[str, ttk.Frame] = {}
+        self._current_frame: Optional[ttk.Frame] = None
         for frame_cls in (StartMenu, ModeSelection, HiLoFrame, WongHalvesFrame):
             frame = frame_cls(container, self)
             self.frames[frame_cls.__name__] = frame
@@ -44,9 +45,16 @@ class CountingApp(tk.Tk):
 
     def show_frame(self, name: str) -> None:
         frame = self.frames[name]
+
+        if self._current_frame is not None and hasattr(self._current_frame, "on_hide"):
+            self._current_frame.on_hide()  # type: ignore[call-arg]
+
+        frame.tkraise()
+
         if hasattr(frame, "on_show"):
             frame.on_show()  # type: ignore[call-arg]
-        frame.tkraise()
+
+        self._current_frame = frame
 
     def start_mode(self, frame_name: str, decks: float = 6.0) -> None:
         frame = self.frames[frame_name]

--- a/blackjack_counter/frames/wong.py
+++ b/blackjack_counter/frames/wong.py
@@ -6,7 +6,7 @@
 # - We keep the low/high shortcuts so players can apply generic +1/-1 presses as needed.
 
 from tkinter import ttk
-from typing import TYPE_CHECKING
+from typing import Dict, Iterable, TYPE_CHECKING
 
 from blackjack_counter.formatting import format_increment
 from blackjack_counter.frames.base import BaseModeFrame
@@ -34,6 +34,22 @@ class WongHalvesFrame(BaseModeFrame):
         "A": -1.0,
     }
 
+    CARD_KEY_BINDINGS: Dict[str, Iterable[str]] = {
+        "2": ("q",),
+        "3": ("w",),
+        "4": ("e",),
+        "5": ("r",),
+        "6": ("a",),
+        "7": ("s",),
+        "8": ("d",),
+        "9": ("f",),
+        "10": ("h",),
+        "J": ("j",),
+        "Q": ("k",),
+        "K": ("l",),
+        "A": ("g",),
+    }
+
     def __init__(self, master: ttk.Frame, controller: "CountingApp") -> None:
         super().__init__(master, controller)
 
@@ -58,8 +74,10 @@ class WongHalvesFrame(BaseModeFrame):
 
         control_frame = ttk.Frame(top_panel)
         control_frame.grid(row=0, column=0, sticky="nsew", padx=(0, 10))
-        ttk.Button(control_frame, text="Reset Shoe", command=self._reset_shoe).pack(fill="x", pady=(0, 10))
-        ttk.Button(control_frame, text="Menu", command=self._go_menu).pack(fill="x")
+        self.reset_button = ttk.Button(control_frame, text="Reset Shoe [Ctrl+R]", command=self._reset_shoe)
+        self.reset_button.pack(fill="x", pady=(0, 10))
+        self.menu_button = ttk.Button(control_frame, text="Menu", command=self._go_menu)
+        self.menu_button.pack(fill="x")
 
         history_frame = ttk.Frame(top_panel, padding=(10, 0))
         history_frame.grid(row=0, column=1, sticky="nsew")
@@ -78,7 +96,12 @@ class WongHalvesFrame(BaseModeFrame):
         self._bind_wraplength(history_label, history_box)
         self._freeze_panel_width(history_frame, column_manager=top_panel, column_index=1, inner=history_box)
 
-        ttk.Button(history_frame, text="Low (+1)", command=lambda: self._record_generic("Low", 1.0)).grid(row=1, column=0, sticky="ew", pady=(12, 0))
+        self.low_button = ttk.Button(
+            history_frame,
+            text="Low (+1) [A/-/←]",
+            command=lambda: self._record_generic("Low", 1.0),
+        )
+        self.low_button.grid(row=1, column=0, sticky="ew", pady=(12, 0))
 
         true_frame = ttk.Frame(top_panel, padding=(10, 0))
         true_frame.grid(row=0, column=2, sticky="nsew")
@@ -88,7 +111,10 @@ class WongHalvesFrame(BaseModeFrame):
         true_box.grid(row=0, column=0, sticky="nsew")
         ttk.Label(true_box, textvariable=self.true_var, style="Value.TLabel", anchor="center").pack(fill="x")
         ttk.Label(true_box, textvariable=self.cards_var, style="Caption.TLabel", anchor="center").pack(fill="x", pady=(8, 0))
-        ttk.Button(true_frame, text="Undo", command=self._undo_entry).grid(row=1, column=0, sticky="ew", pady=(12, 0))
+        self.undo_button = ttk.Button(true_frame, text="Undo [< / Ctrl+Z]", command=self._undo_entry)
+        self.undo_button.grid(row=1, column=0, sticky="ew", pady=(12, 6))
+        self.redo_button = ttk.Button(true_frame, text="Redo [> / Ctrl+Shift+Z]", command=self._redo_entry)
+        self.redo_button.grid(row=2, column=0, sticky="ew")
 
         running_frame = ttk.Frame(top_panel, padding=(10, 0))
         running_frame.grid(row=0, column=3, sticky="nsew")
@@ -97,7 +123,12 @@ class WongHalvesFrame(BaseModeFrame):
         running_box = ttk.LabelFrame(running_frame, text="Running Count", padding=10)
         running_box.grid(row=0, column=0, sticky="nsew")
         ttk.Label(running_box, textvariable=self.running_var, style="Value.TLabel", anchor="center").pack(fill="x")
-        ttk.Button(running_frame, text="Hi (-1)", command=lambda: self._record_generic("Hi", -1.0)).grid(row=1, column=0, sticky="ew", pady=(12, 0))
+        self.hi_button = ttk.Button(
+            running_frame,
+            text="Hi (-1) [D/+/→]",
+            command=lambda: self._record_generic("Hi", -1.0),
+        )
+        self.hi_button.grid(row=1, column=0, sticky="ew", pady=(12, 0))
 
         for column in range(len(self.CARD_VALUES)):
             bottom_panel.columnconfigure(column, weight=1, uniform="cards")
@@ -105,9 +136,14 @@ class WongHalvesFrame(BaseModeFrame):
 
         cards = list(self.CARD_VALUES.items())
         for index, (card, value) in enumerate(cards):
+            hints = " / ".join(key.upper() for key in self.CARD_KEY_BINDINGS.get(card, ()))
+            label = f"{card}\n({format_increment(value)})"
+            if hints:
+                label += f"\n[{hints}]"
+
             ttk.Button(
                 bottom_panel,
-                text=f"{card}\n({format_increment(value)})",
+                text=label,
                 style="Card.TButton",
                 command=lambda c=card, v=value: self._record_card(c, v),
             ).grid(row=0, column=index, padx=2, pady=3, sticky="nsew")
@@ -131,3 +167,52 @@ class WongHalvesFrame(BaseModeFrame):
         # sums those values to produce the running and true counts displayed.
         self.state.record(card, value)
         self.refresh()
+
+    def on_show(self) -> None:
+        super().on_show()
+
+        def _wrap_generic(label: str, value: float):
+            def handler(event):
+                self._record_generic(label, value)
+                return "break"
+
+            return handler
+
+        for sequence in (
+            "<KeyPress-a>",
+            "<KeyPress-A>",
+            "<KeyPress-minus>",
+            "<minus>",
+            "<Left>",
+        ):
+            self._bind_shortcut(sequence, _wrap_generic("Low", 1.0))
+
+        for sequence in (
+            "<KeyPress-d>",
+            "<KeyPress-D>",
+            "<KeyPress-plus>",
+            "<plus>",
+            "<Right>",
+        ):
+            self._bind_shortcut(sequence, _wrap_generic("Hi", -1.0))
+
+        for card, keys in self.CARD_KEY_BINDINGS.items():
+            value = self.CARD_VALUES[card]
+
+            def _make_handler(c: str, v: float):
+                def handler(event):
+                    self._record_card(c, v)
+                    return "break"
+
+                return handler
+
+            handler = _make_handler(card, value)
+            for key in keys:
+                sequences = [f"<KeyPress-{key}>"]
+                if key.isalpha():
+                    sequences.append(f"<KeyPress-{key.upper()}>")
+                for sequence in sequences:
+                    self._bind_shortcut(sequence, handler)
+
+    def on_hide(self) -> None:
+        super().on_hide()


### PR DESCRIPTION
## Summary
- track the active frame so shared on_show/on_hide hooks can manage keyboard shortcuts
- add shortcut bindings, redo controls, and visible hotkey hints to the Hi-Lo and Wong layouts
- extend the counting state with a redo stack that enforces a five-step undo limit

## Testing
- python -m compileall blackjack_counter

------
https://chatgpt.com/codex/tasks/task_e_68dceebf72b8832da5a7064c7bd1c5b1