### PR TITLE
Document hotkeys and expand redo history

### DIFF
--- a/blackjack_counter/app.py
+++ b/blackjack_counter/app.py
@@ -2,7 +2,7 @@
 
 import tkinter as tk
 from tkinter import ttk
-from typing import Dict
+from typing import Dict, Optional
 
 from blackjack_counter.frames.hilo import HiLoFrame
 from blackjack_counter.frames.menu import ModeSelection, StartMenu
@@ -27,6 +27,7 @@ class CountingApp(tk.Tk):
         container.grid_columnconfigure(0, weight=1)
 
         self.frames: Dict[str, ttk.Frame] = {}
+        self._current_frame: Optional[ttk.Frame] = None
         for frame_cls in (StartMenu, ModeSelection, HiLoFrame, WongHalvesFrame):
             frame = frame_cls(container, self)
             self.frames[frame_cls.__name__] = frame
@@ -44,9 +45,16 @@ class CountingApp(tk.Tk):
 
     def show_frame(self, name: str) -> None:
         frame = self.frames[name]
+
+        if self._current_frame is not None and hasattr(self._current_frame, "on_hide"):
+            self._current_frame.on_hide()  # type: ignore[call-arg]
+
+        frame.tkraise()
+
         if hasattr(frame, "on_show"):
             frame.on_show()  # type: ignore[call-arg]
-        frame.tkraise()
+
+        self._current_frame = frame
 
     def start_mode(self, frame_name: str, decks: float = 6.0) -> None:
         frame = self.frames[frame_name]

--- a/blackjack_counter/frames/hilo.py
+++ b/blackjack_counter/frames/hilo.py
@@ -5,7 +5,7 @@
 # - Cards ranked 10, face cards, and aces are "high" and subtract 1 from the running count.
 # - The interface mirrors that logic with Low/Hi buttons; each press records the adjustment and refreshes totals.
 
-from tkinter import ttk
+from tkinter import messagebox, ttk
 from typing import TYPE_CHECKING
 
 from blackjack_counter.frames.base import BaseModeFrame
@@ -32,8 +32,12 @@ class HiLoFrame(BaseModeFrame):
         control_frame = ttk.Frame(self)
         control_frame.grid(row=0, column=0, sticky="nsew", padx=(0, 10))
 
-        ttk.Button(control_frame, text="Reset Shoe", command=self._reset_shoe).pack(fill="x", pady=(0, 10))
-        ttk.Button(control_frame, text="Menu", command=self._go_menu).pack(fill="x")
+        self.reset_button = ttk.Button(control_frame, text="Reset Shoe [Ctrl+R]", command=self._reset_shoe)
+        self.reset_button.pack(fill="x", pady=(0, 10))
+        self.menu_button = ttk.Button(control_frame, text="Menu", command=self._go_menu)
+        self.menu_button.pack(fill="x")
+        self.hotkey_button = ttk.Button(control_frame, text="Hotkeys…", command=self._show_hotkeys)
+        self.hotkey_button.pack(fill="x", pady=(10, 0))
 
         history_frame = ttk.Frame(self, padding=(10, 0))
         history_frame.grid(row=0, column=1, sticky="nsew")
@@ -52,7 +56,12 @@ class HiLoFrame(BaseModeFrame):
         self._bind_wraplength(history_label, history_box)
         self._freeze_panel_width(history_frame, column_manager=self, column_index=1, inner=history_box)
 
-        ttk.Button(history_frame, text="Low (+1)", command=lambda: self._record("Low", 1.0)).grid(row=1, column=0, sticky="ew", pady=(12, 0))
+        self.low_button = ttk.Button(
+            history_frame,
+            text="Low (+1) [A/-/←]",
+            command=lambda: self._record("Low", 1.0),
+        )
+        self.low_button.grid(row=1, column=0, sticky="ew", pady=(12, 0))
 
         true_frame = ttk.Frame(self, padding=(10, 0))
         true_frame.grid(row=0, column=2, sticky="nsew")
@@ -63,7 +72,10 @@ class HiLoFrame(BaseModeFrame):
         ttk.Label(true_box, textvariable=self.true_var, style="Value.TLabel", anchor="center").pack(fill="x")
         ttk.Label(true_box, textvariable=self.cards_var, style="Caption.TLabel", anchor="center").pack(fill="x", pady=(8, 0))
 
-        ttk.Button(true_frame, text="Undo", command=self._undo_entry).grid(row=1, column=0, sticky="ew", pady=(12, 0))
+        self.undo_button = ttk.Button(true_frame, text="Undo [< / Ctrl+Z]", command=self._undo_entry)
+        self.undo_button.grid(row=1, column=0, sticky="ew", pady=(12, 6))
+        self.redo_button = ttk.Button(true_frame, text="Redo [> / Ctrl+Shift+Z]", command=self._redo_entry)
+        self.redo_button.grid(row=2, column=0, sticky="ew")
 
         running_frame = ttk.Frame(self, padding=(10, 0))
         running_frame.grid(row=0, column=3, sticky="nsew")
@@ -73,7 +85,12 @@ class HiLoFrame(BaseModeFrame):
         running_box.grid(row=0, column=0, sticky="nsew")
         ttk.Label(running_box, textvariable=self.running_var, style="Value.TLabel", anchor="center").pack(fill="x")
 
-        ttk.Button(running_frame, text="Hi (-1)", command=lambda: self._record("Hi", -1.0)).grid(row=1, column=0, sticky="ew", pady=(12, 0))
+        self.hi_button = ttk.Button(
+            running_frame,
+            text="Hi (-1) [D/+/→]",
+            command=lambda: self._record("Hi", -1.0),
+        )
+        self.hi_button.grid(row=1, column=0, sticky="ew", pady=(12, 0))
 
     def _record(self, label: str, value: float) -> None:
         """Store the Hi-Lo adjustment so the shared state can update counts."""
@@ -84,3 +101,57 @@ class HiLoFrame(BaseModeFrame):
         # the running and true counts from that history so the labels stay current.
         self.state.record(label, value)
         self.refresh()
+
+    def on_show(self) -> None:
+        super().on_show()
+
+        def _wrap_low(event):
+            self._record("Low", 1.0)
+            return "break"
+
+        def _wrap_hi(event):
+            self._record("Hi", -1.0)
+            return "break"
+
+        for sequence in (
+            "<KeyPress-l>",
+            "<KeyPress-L>",
+            "<KeyPress-a>",
+            "<KeyPress-A>",
+            "<KeyPress-minus>",
+            "<minus>",
+            "<Left>",
+            "<Down>",
+            "<KeyPress-bracketleft>",
+            "<bracketleft>",
+        ):
+            self._bind_shortcut(sequence, _wrap_low)
+
+        for sequence in (
+            "<KeyPress-h>",
+            "<KeyPress-H>",
+            "<KeyPress-d>",
+            "<KeyPress-D>",
+            "<KeyPress-plus>",
+            "<plus>",
+            "<Right>",
+            "<Up>",
+            "<KeyPress-bracketright>",
+            "<bracketright>",
+        ):
+            self._bind_shortcut(sequence, _wrap_hi)
+
+    def on_hide(self) -> None:
+        super().on_hide()
+
+    def _show_hotkeys(self) -> None:
+        """Present a quick reference of the Hi-Lo keyboard shortcuts."""
+
+        hotkeys = (
+            "Low (+1): L, A, -, Left Arrow, Down Arrow, [",
+            "Hi (-1): H, D, +, Right Arrow, Up Arrow, ]",
+            "Undo: <, ,, Ctrl+Z",
+            "Redo: >, ., Ctrl+Shift+Z",
+            "Reset Shoe: Ctrl+R",
+        )
+        messagebox.showinfo("Hi-Lo Hotkeys", "\n".join(hotkeys), parent=self)

--- a/blackjack_counter/frames/wong.py
+++ b/blackjack_counter/frames/wong.py
@@ -5,8 +5,8 @@
 # - The buttons for 2 through A add those fractional adjustments to the running count.
 # - We keep the low/high shortcuts so players can apply generic +1/-1 presses as needed.
 
-from tkinter import ttk
-from typing import TYPE_CHECKING
+from tkinter import messagebox, ttk
+from typing import Dict, Iterable, TYPE_CHECKING
 
 from blackjack_counter.formatting import format_increment
 from blackjack_counter.frames.base import BaseModeFrame
@@ -34,6 +34,22 @@ class WongHalvesFrame(BaseModeFrame):
         "A": -1.0,
     }
 
+    CARD_KEY_BINDINGS: Dict[str, Iterable[str]] = {
+        "2": ("q",),
+        "3": ("w",),
+        "4": ("e",),
+        "5": ("r",),
+        "6": ("a",),
+        "7": ("s",),
+        "8": ("d",),
+        "9": ("f",),
+        "10": ("h",),
+        "J": ("j",),
+        "Q": ("k",),
+        "K": ("l",),
+        "A": ("g",),
+    }
+
     def __init__(self, master: ttk.Frame, controller: "CountingApp") -> None:
         super().__init__(master, controller)
 
@@ -58,8 +74,12 @@ class WongHalvesFrame(BaseModeFrame):
 
         control_frame = ttk.Frame(top_panel)
         control_frame.grid(row=0, column=0, sticky="nsew", padx=(0, 10))
-        ttk.Button(control_frame, text="Reset Shoe", command=self._reset_shoe).pack(fill="x", pady=(0, 10))
-        ttk.Button(control_frame, text="Menu", command=self._go_menu).pack(fill="x")
+        self.reset_button = ttk.Button(control_frame, text="Reset Shoe [Ctrl+R]", command=self._reset_shoe)
+        self.reset_button.pack(fill="x", pady=(0, 10))
+        self.menu_button = ttk.Button(control_frame, text="Menu", command=self._go_menu)
+        self.menu_button.pack(fill="x")
+        self.hotkey_button = ttk.Button(control_frame, text="Hotkeys…", command=self._show_hotkeys)
+        self.hotkey_button.pack(fill="x", pady=(10, 0))
 
         history_frame = ttk.Frame(top_panel, padding=(10, 0))
         history_frame.grid(row=0, column=1, sticky="nsew")
@@ -78,7 +98,12 @@ class WongHalvesFrame(BaseModeFrame):
         self._bind_wraplength(history_label, history_box)
         self._freeze_panel_width(history_frame, column_manager=top_panel, column_index=1, inner=history_box)
 
-        ttk.Button(history_frame, text="Low (+1)", command=lambda: self._record_generic("Low", 1.0)).grid(row=1, column=0, sticky="ew", pady=(12, 0))
+        self.low_button = ttk.Button(
+            history_frame,
+            text="Low (+1) [A/-/←]",
+            command=lambda: self._record_generic("Low", 1.0),
+        )
+        self.low_button.grid(row=1, column=0, sticky="ew", pady=(12, 0))
 
         true_frame = ttk.Frame(top_panel, padding=(10, 0))
         true_frame.grid(row=0, column=2, sticky="nsew")
@@ -88,7 +113,10 @@ class WongHalvesFrame(BaseModeFrame):
         true_box.grid(row=0, column=0, sticky="nsew")
         ttk.Label(true_box, textvariable=self.true_var, style="Value.TLabel", anchor="center").pack(fill="x")
         ttk.Label(true_box, textvariable=self.cards_var, style="Caption.TLabel", anchor="center").pack(fill="x", pady=(8, 0))
-        ttk.Button(true_frame, text="Undo", command=self._undo_entry).grid(row=1, column=0, sticky="ew", pady=(12, 0))
+        self.undo_button = ttk.Button(true_frame, text="Undo [< / Ctrl+Z]", command=self._undo_entry)
+        self.undo_button.grid(row=1, column=0, sticky="ew", pady=(12, 6))
+        self.redo_button = ttk.Button(true_frame, text="Redo [> / Ctrl+Shift+Z]", command=self._redo_entry)
+        self.redo_button.grid(row=2, column=0, sticky="ew")
 
         running_frame = ttk.Frame(top_panel, padding=(10, 0))
         running_frame.grid(row=0, column=3, sticky="nsew")
@@ -97,7 +125,12 @@ class WongHalvesFrame(BaseModeFrame):
         running_box = ttk.LabelFrame(running_frame, text="Running Count", padding=10)
         running_box.grid(row=0, column=0, sticky="nsew")
         ttk.Label(running_box, textvariable=self.running_var, style="Value.TLabel", anchor="center").pack(fill="x")
-        ttk.Button(running_frame, text="Hi (-1)", command=lambda: self._record_generic("Hi", -1.0)).grid(row=1, column=0, sticky="ew", pady=(12, 0))
+        self.hi_button = ttk.Button(
+            running_frame,
+            text="Hi (-1) [D/+/→]",
+            command=lambda: self._record_generic("Hi", -1.0),
+        )
+        self.hi_button.grid(row=1, column=0, sticky="ew", pady=(12, 0))
 
         for column in range(len(self.CARD_VALUES)):
             bottom_panel.columnconfigure(column, weight=1, uniform="cards")
@@ -105,9 +138,14 @@ class WongHalvesFrame(BaseModeFrame):
 
         cards = list(self.CARD_VALUES.items())
         for index, (card, value) in enumerate(cards):
+            hints = " / ".join(key.upper() for key in self.CARD_KEY_BINDINGS.get(card, ()))
+            label = f"{card}\n({format_increment(value)})"
+            if hints:
+                label += f"\n[{hints}]"
+
             ttk.Button(
                 bottom_panel,
-                text=f"{card}\n({format_increment(value)})",
+                text=label,
                 style="Card.TButton",
                 command=lambda c=card, v=value: self._record_card(c, v),
             ).grid(row=0, column=index, padx=2, pady=3, sticky="nsew")
@@ -131,3 +169,80 @@ class WongHalvesFrame(BaseModeFrame):
         # sums those values to produce the running and true counts displayed.
         self.state.record(card, value)
         self.refresh()
+
+    def on_show(self) -> None:
+        super().on_show()
+
+        def _wrap_generic(label: str, value: float):
+            def handler(event):
+                self._record_generic(label, value)
+                return "break"
+
+            return handler
+
+        for sequence in (
+            "<KeyPress-a>",
+            "<KeyPress-A>",
+            "<KeyPress-minus>",
+            "<minus>",
+            "<Left>",
+        ):
+            self._bind_shortcut(sequence, _wrap_generic("Low", 1.0))
+
+        for sequence in (
+            "<KeyPress-d>",
+            "<KeyPress-D>",
+            "<KeyPress-plus>",
+            "<plus>",
+            "<Right>",
+        ):
+            self._bind_shortcut(sequence, _wrap_generic("Hi", -1.0))
+
+        for card, keys in self.CARD_KEY_BINDINGS.items():
+            value = self.CARD_VALUES[card]
+
+            def _make_handler(c: str, v: float):
+                def handler(event):
+                    self._record_card(c, v)
+                    return "break"
+
+                return handler
+
+            handler = _make_handler(card, value)
+            for key in keys:
+                sequences = [f"<KeyPress-{key}>"]
+                if key.isalpha():
+                    sequences.append(f"<KeyPress-{key.upper()}>")
+                for sequence in sequences:
+                    self._bind_shortcut(sequence, handler)
+
+    def on_hide(self) -> None:
+        super().on_hide()
+
+    def _show_hotkeys(self) -> None:
+        """Display the key bindings for the Wong Halves layout."""
+
+        card_hints = [
+            "2: Q",
+            "3: W",
+            "4: E",
+            "5: R",
+            "6: A",
+            "7: S",
+            "8: D",
+            "9: F",
+            "10: H",
+            "J: J",
+            "Q: K",
+            "K: L",
+            "A: G",
+        ]
+        hotkeys = (
+            "Low (+1): A, -, Left Arrow",
+            "Hi (-1): D, +, Right Arrow",
+            "Cards:\n  " + "\n  ".join(card_hints),
+            "Undo: <, ,, Ctrl+Z",
+            "Redo: >, ., Ctrl+Shift+Z",
+            "Reset Shoe: Ctrl+R",
+        )
+        messagebox.showinfo("Wong Halves Hotkeys", "\n\n".join(hotkeys), parent=self)

--- a/blackjack_counter/state.py
+++ b/blackjack_counter/state.py
@@ -18,23 +18,52 @@ class CountingState:
     def __init__(self, decks: float = 6.0) -> None:
         self.decks_total = decks
         self.history: List[CountEntry] = []
+        self._redo_stack: List[CountEntry] = []
+        self._undo_limit = 20
 
     def reset(self) -> None:
         """Clear all recorded cards and adjustments."""
 
         self.history.clear()
+        self._redo_stack.clear()
 
     def record(self, label: str, value: float) -> None:
         """Append a new adjustment to the running count history."""
 
         self.history.append(CountEntry(label, value))
+        self._redo_stack.clear()
 
     def undo(self) -> Optional[CountEntry]:
         """Remove and return the most recent entry if one exists."""
 
-        if self.history:
-            return self.history.pop()
-        return None
+        if not self.history or len(self._redo_stack) >= self._undo_limit:
+            return None
+
+        entry = self.history.pop()
+        self._redo_stack.append(entry)
+        return entry
+
+    def redo(self) -> Optional[CountEntry]:
+        """Reapply the most recently undone entry if available."""
+
+        if not self._redo_stack:
+            return None
+
+        entry = self._redo_stack.pop()
+        self.history.append(entry)
+        return entry
+
+    @property
+    def can_undo(self) -> bool:
+        """Indicate whether an undo action is currently allowed."""
+
+        return bool(self.history) and len(self._redo_stack) < self._undo_limit
+
+    @property
+    def can_redo(self) -> bool:
+        """Indicate whether a redo action is currently allowed."""
+
+        return bool(self._redo_stack)
 
     @property
     def running_count(self) -> float:


### PR DESCRIPTION
## Summary
- raise the redo history ceiling to twenty actions so longer sessions can be replayed
- add compact hotkey reference buttons to the Hi-Lo and Wong Halves layouts
- extend Hi-Lo bindings to cover additional ergonomic key pairs and surface them in the help dialog

## Testing
- python -m compileall blackjack_counter

------
https://chatgpt.com/codex/tasks/task_e_68dceebf72b8832da5a7064c7bd1c5b1