### PR TITLE
Align Hi-Lo controls within running count panel

### DIFF
--- a/blackjack_counter/frames/hilo.py
+++ b/blackjack_counter/frames/hilo.py
@@ -132,15 +132,6 @@ class HiLoFrame(BaseModeFrame):
         self._bind_wraplength(history_label, history_box)
         self._freeze_panel_width(history_frame, column_manager=self, column_index=1, inner=history_box)
 
-        self.low_button = ttk.Button(
-            history_frame,
-
-            text="Low (+1)",
-
-            command=lambda: self._record("Low", 1.0),
-        )
-        self.low_button.grid(row=1, column=0, sticky="ew", pady=(8, 0))
-
         true_frame = ttk.Frame(self, padding=(6, 0))
         true_frame.grid(row=0, column=2, sticky="nsew")
         true_frame.columnconfigure(0, weight=1)
@@ -163,14 +154,41 @@ class HiLoFrame(BaseModeFrame):
         running_box.grid(row=0, column=0, sticky="nsew")
         ttk.Label(running_box, textvariable=self.running_var, style="Value.TLabel", anchor="center").pack(fill="x")
 
+        button_section = ttk.Frame(running_frame)
+        button_section.grid(row=1, column=0, sticky="ew", pady=(8, 0))
+        button_section.columnconfigure(0, weight=1)
+        button_section.columnconfigure(1, weight=1)
+
+        ttk.Label(
+            button_section,
+            text="Lo cards: 2, 3, 4, 5, 6",
+            style="Caption.TLabel",
+            anchor="center",
+        ).grid(row=0, column=0, sticky="ew", padx=(0, 4))
+        ttk.Label(
+            button_section,
+            text="Hi cards: 10, J, Q, K, A",
+            style="Caption.TLabel",
+            anchor="center",
+        ).grid(row=0, column=1, sticky="ew", padx=(4, 0))
+
+        self.low_button = ttk.Button(
+            button_section,
+
+            text="Low (+1)",
+
+            command=lambda: self._record("Low", 1.0),
+        )
+        self.low_button.grid(row=1, column=0, sticky="ew", padx=(0, 4), pady=(4, 0))
+
         self.hi_button = ttk.Button(
-            running_frame,
+            button_section,
 
             text="Hi (-1)",
 
             command=lambda: self._record("Hi", -1.0),
         )
-        self.hi_button.grid(row=1, column=0, sticky="ew", pady=(8, 0))
+        self.hi_button.grid(row=1, column=1, sticky="ew", padx=(4, 0), pady=(4, 0))
         bottom_bar = ttk.Frame(self, padding=(6, 4))
         bottom_bar.grid(row=1, column=0, columnspan=4, sticky="ew")
         bottom_bar.columnconfigure(0, weight=2)


### PR DESCRIPTION
## Summary
- relocate the Low button next to the Hi button within the running count panel
- display Hi and Lo card references directly above their respective buttons for quick reference
- ensure the buttons share equal width for a balanced layout

## Testing
- python -m compileall blackjack_counter

------
https://chatgpt.com/codex/tasks/task_e_68e0793d4324832d94a71aceb311a33e